### PR TITLE
Properly generate static resources on deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python manage.py migrate && gunicorn mysite.wsgi
+web: python manage.py migrate && python manage.py collectstatic --noinput && gunicorn mysite.wsgi


### PR DESCRIPTION
Django requires a generated static folder when deployed in a production environment, this fixes that by (re)generating static content on deploy